### PR TITLE
Fix empty geometry in case of immediate attribute window pop-up

### DIFF
--- a/FormAwareValueRelationWidget.py
+++ b/FormAwareValueRelationWidget.py
@@ -350,7 +350,8 @@ class FormAwareValueRelationWidgetWrapper(QgsEditorWidgetWrapper):
                 if isinstance(c, QgsEditorWidgetWrapper) and c != self and c.field().name().lower() != self.config( "Key" ).lower():
                     form_vars[c.field().name()] = c.value()
             if self.mFeature:
-                form_vars['wkt_geom'] = self.mFeature.geometry().exportToWkt(8)
+				if self.mFeature.geometry():
+					form_vars['wkt_geom'] = self.mFeature.geometry().exportToWkt(8)
 
         # Last chance to find values
         if not is_form or 0 == len(form_vars):


### PR DESCRIPTION
Hi @elpaso 

This is a quick fix for #20 and worked for us. 